### PR TITLE
server side SNI and bug fixes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 ThisBuild / scalaVersion := "3.2.1"
-ThisBuild / version := "0.4.5"
+ThisBuild / version := "0.4.6"
 ThisBuild / organization := "io.github.ollls"
 ThisBuild / organizationName := "ollls"
 ThisBuild / versionScheme := Some("strict")

--- a/examples/IO/src/main/scala/Run.scala
+++ b/examples/IO/src/main/scala/Run.scala
@@ -34,6 +34,16 @@ object MyApp extends IOApp {
 
   val R: HttpRouteIO = {
 
+    case req @ GET -> Root / "sninames" =>
+      for {
+        _ <-
+          req.stream.compile.drain // properly ignore incoming data, we must flush it, generaly if you sure there will be no data, you can ignore.
+        result_text <- IO(req.sniServerNames match {
+          case Some(hosts) => s"Host names in TLS SNI extension: ${hosts.mkString(",")}"
+          case None        => "No TLS SNI host names provided or unsecured connection"
+        })
+      } yield (Response.Ok().asText(result_text))
+
     case req @ GET -> Root / "headers" =>
       IO(Response.Ok().asText(s"connId=${req.connId} streamId=${req.streamId}\n${req.headers.printHeaders}"))
 

--- a/examples/IO/src/main/scala/Run.scala
+++ b/examples/IO/src/main/scala/Run.scala
@@ -33,14 +33,13 @@ object MyApp extends IOApp {
   var HOME_DIR = "/Users/ostrygun/" // last slash is important!
 
   val R: HttpRouteIO = {
-
-    case req @ GET -> Root / "sninames" =>
+    case req @ GET -> Root / "snihost" =>
       for {
         _ <-
           req.stream.compile.drain // properly ignore incoming data, we must flush it, generaly if you sure there will be no data, you can ignore.
         result_text <- IO(req.sniServerNames match {
           case Some(hosts) => s"Host names in TLS SNI extension: ${hosts.mkString(",")}"
-          case None        => "No TLS SNI host names provided or unsecured connection"
+          case None        => "No TLS SNI host names provided or unsecure connection"
         })
       } yield (Response.Ok().asText(result_text))
 

--- a/examples/IO/src/main/scala/Run.scala
+++ b/examples/IO/src/main/scala/Run.scala
@@ -122,7 +122,7 @@ object MyApp extends IOApp {
 
   def run(args: List[String]): IO[ExitCode] =
     for {
-      ctx <- QuartzH2Server.buildSSLContext("TLS", "keystore.jks", "password")
+      ctx <- QuartzH2Server.buildSSLContext("TLSv1.3", "keystore.jks", "password")
       exitCode <- new QuartzH2Server("localhost", 8443, 16000, ctx) // incomingWinSize = 3145728)
         .startIO(R, filter, sync = false)
 

--- a/examples/IO/src/main/scala/Run.scala
+++ b/examples/IO/src/main/scala/Run.scala
@@ -85,7 +85,9 @@ object MyApp extends IOApp {
     // perf tests
     case GET -> Root / "test" => IO(Response.Ok())
 
-    case GET -> Root / "example" =>
+    //virtual hosting with TLS SNI.
+    //example with SniHostName passed as parmeter for "!" operator 
+    case "localhost" ! GET -> Root / "example" =>
       // how to send data in separate H2 packets of various size.
       val ts = Stream.emits("Block1\n".getBytes())
       val ts2 = ts ++ Stream.emits("Block22\n".getBytes())

--- a/examples/IO/src/main/scala/Run.scala
+++ b/examples/IO/src/main/scala/Run.scala
@@ -15,6 +15,8 @@ import io.quartz.http2.model.StatusCode
 import io.quartz.http2.routes.WebFilter
 import cats.syntax.all.catsSyntaxApplicativeByName
 import concurrent.duration.DurationInt
+import org.typelevel.log4cats.Logger
+import io.quartz.MyLogger._
 
 object param1 extends QueryParam("param1")
 object param2 extends QueryParam("param2")
@@ -69,7 +71,7 @@ object MyApp extends IOApp {
     case req @ POST -> Root / "upload" / StringVar(_) =>
       for {
         reqPath <- IO(Path(HOME_DIR + req.uri.getPath()))
-        _ <- IO.println(reqPath.toString)
+        _ <- Logger[IO].info( s"Saving: ${reqPath.toString}")
         _ <- req.stream.through(Files[IO].writeAll(reqPath)).compile.drain
         // _ <- req.stream.chunks.foreach( bb => IO.sleep( 1000.millis)).compile.drain
 
@@ -123,7 +125,7 @@ object MyApp extends IOApp {
   def run(args: List[String]): IO[ExitCode] =
     for {
       ctx <- QuartzH2Server.buildSSLContext("TLSv1.3", "keystore.jks", "password")
-      exitCode <- new QuartzH2Server("localhost", 8443, 16000, ctx) // incomingWinSize = 3145728)
+      exitCode <- new QuartzH2Server("localhost", 8443, 16000, ctx) //, incomingWinSize = 1000000)
         .startIO(R, filter, sync = false)
 
     } yield (exitCode)

--- a/src/main/scala/io/quartz/QuartzH2Server.scala
+++ b/src/main/scala/io/quartz/QuartzH2Server.scala
@@ -107,7 +107,7 @@ object QuartzH2Server {
   *   the SSL context to use for secure connections, can be null for non-secure connections
   * @param incomingWinSize
   *   the initial window size for incoming flow control
-  * @param onConnect 
+  * @param onConnect
   *   callback function that is called when a connection is established, provides connectionId : Long as an argument
   * @param onDisconnect
   *   callback function that is called when a connection is terminated, provides connectionId : Long as an argument
@@ -308,7 +308,7 @@ class QuartzH2Server(
     e match {
       case BadProtocol(ch, e) =>
         Logger[IO].error("Cannot see HTTP2 Preface, bad protocol (1)") >>
-        ch.write(Frames.mkGoAwayFrame(0, Error.PROTOCOL_ERROR, "".getBytes))
+          ch.write(Frames.mkGoAwayFrame(0, Error.PROTOCOL_ERROR, "".getBytes))
       case e: java.nio.channels.InterruptedByTimeoutException =>
         Logger[IO].info("Remote peer disconnected on timeout")
       case _ => Logger[IO].error("errorHandler: " + e.toString)
@@ -384,6 +384,17 @@ class QuartzH2Server(
     }
   }
 
+  private def printSniName(names: Option[Array[String]]) = {
+    names match {
+      case Some(value) => value(0)
+      case None        => "not provided"
+    }
+  }
+
+  private def tlsPrint(c: TLSChannel) = {
+    c.f_SSL.engine.getSession().getCipherSuite()
+  }
+
   def run0(e: ExecutorService, R: HttpRoute, maxThreadNum: Int, maxStreams: Int, keepAliveMs: Int): IO[ExitCode] = {
     for {
       addr <- IO(new InetSocketAddress(HOST, PORT))
@@ -414,6 +425,11 @@ class QuartzH2Server(
         .flatMap(ch =>
           (IO(TLSChannel(sslCtx, ch))
             .flatMap(c => c.ssl_init_h2().map((c, _)))
+            .flatTap(c =>
+              Logger[IO].info(
+                s"${c._1.ctx.getProtocol()} ${tlsPrint(c._1)} ${c._1.f_SSL.engine.getApplicationProtocol()} tls-sni: ${printSniName(c._1.sniServerNames())}"
+              )
+            )
             .flatTap(_ => conId.update(_ + 1))
             .bracket(ch =>
               doConnect(ch._1, conId, maxStreams, keepAliveMs, R, ch._2).handleErrorWith(e => { errorHandler(e) })

--- a/src/main/scala/io/quartz/QuartzH2Server.scala
+++ b/src/main/scala/io/quartz/QuartzH2Server.scala
@@ -276,7 +276,7 @@ class QuartzH2Server(
 
       emptyTH <- Deferred[IO, Headers] // no trailing headers for 1.1
       _ <- emptyTH.complete(Headers()) // complete with empty
-      http11request <- IO(Some(Request(id, 1, headers11, res, emptyTH)))
+      http11request <- IO(Some(Request(id, 1, headers11, res, ch.secure(), ch.sniServerNames(), emptyTH)))
       upd = headers11.get("upgrade").getOrElse("")
       _ <- Logger[IO].trace("doConnectUpgrade() - Upgrade = " + upd)
       clientPreface <-

--- a/src/main/scala/io/quartz/QuartzH2Server.scala
+++ b/src/main/scala/io/quartz/QuartzH2Server.scala
@@ -398,7 +398,7 @@ class QuartzH2Server(
   def run0(e: ExecutorService, R: HttpRoute, maxThreadNum: Int, maxStreams: Int, keepAliveMs: Int): IO[ExitCode] = {
     for {
       addr <- IO(new InetSocketAddress(HOST, PORT))
-      _ <- Logger[IO].info("HTTP/2 TLS Service: QuartzH2 (async - Java NIO)")
+      _ <- Logger[IO].info("HTTP/2 TLS Service: QuartzH2 async mode (netio)")
       _ <- Logger[IO].info(s"Concurrency level(max threads): $maxThreadNum, max streams per conection: $maxStreams")
       _ <- Logger[IO].info(s"h2 idle timeout: $keepAliveMs Ms")
       _ <- Logger[IO].info(
@@ -445,7 +445,7 @@ class QuartzH2Server(
   def run1(R: HttpRoute, maxThreadNum: Int, maxStreams: Int, keepAliveMs: Int): IO[ExitCode] = {
     for {
       addr <- IO(new InetSocketAddress(HOST, PORT))
-      _ <- Logger[IO].info("HTTP/2 TLS Service: QuartzH2 ( sync - Java Socket )")
+      _ <- Logger[IO].info("HTTP/2 TLS Service: QuartzH2 sync mode (sockets)")
       _ <- Logger[IO].info(s"Concurrency level(max threads): $maxThreadNum, max streams per conection: $maxStreams")
       _ <- Logger[IO].info(s"h2 idle timeout: $keepAliveMs Ms")
       _ <- Logger[IO].info(s"Listens: ${addr.getHostString()}:${addr.getPort().toString()}")
@@ -488,7 +488,7 @@ class QuartzH2Server(
   def run3(e: ExecutorService, R: HttpRoute, maxThreadNum: Int, maxStreams: Int, keepAliveMs: Int): IO[ExitCode] = {
     for {
       addr <- IO(new InetSocketAddress(HOST, PORT))
-      _ <- Logger[IO].info("HTTP/2 h2c service: QuartzH2 (async - Java NIO)")
+      _ <- Logger[IO].info("HTTP/2 h2c service: QuartzH2 async mode (netio)")
       _ <- Logger[IO].info(s"Concurrency level(max threads): $maxThreadNum, max streams per conection: $maxStreams")
       _ <- Logger[IO].info(s"h2c idle timeout: $keepAliveMs Ms")
       _ <- Logger[IO].info(

--- a/src/main/scala/io/quartz/http2/Http2Connection.scala
+++ b/src/main/scala/io/quartz/http2/Http2Connection.scala
@@ -721,12 +721,14 @@ class Http2Connection(
     val flags = bb.get()
     val streamId = Frames.getStreamId(bb)
 
+    val endStream = if ( (flags & Flags.END_STREAM) != 0 ) true else false
+
     if (requiredLen < len) {
       val buf0 = Array.ofDim[Byte](requiredLen.toInt)
       bb.get(buf0)
 
       val dataFrame1 = Frames.mkDataFrame(streamId, false, padding = 0, ByteBuffer.wrap(buf0))
-      val dataFrame2 = Frames.mkDataFrame(streamId, false, padding = 0, bb)
+      val dataFrame2 = Frames.mkDataFrame(streamId, endStream, padding = 0, bb)
 
       (
         txWindow_SplitDataFrame(dataFrame1, requiredLen.toInt),

--- a/src/main/scala/io/quartz/http2/Http2Connection.scala
+++ b/src/main/scala/io/quartz/http2/Http2Connection.scala
@@ -549,6 +549,8 @@ class Http2Connection(
             if ((flags & Flags.END_STREAM) == Flags.END_STREAM)
               Stream.empty
             else Http2Connection.makeDataStream(this, dataIn),
+            ch.secure(),
+            ch.sniServerNames(),
             trailingHdr
           )
         )
@@ -1367,7 +1369,7 @@ class Http2Connection(
                         val stream = x.stream
                         val th = x.trailingHeaders
                         val h = x.headers.drop("connection")
-                        this.openStream11(1, Request(id, 1, h, stream, th))
+                        this.openStream11(1, Request(id, 1, h, stream, ch.secure(), ch.sniServerNames(), th))
                       }
                       case None => IO.unit
                     }).whenA(start)

--- a/src/main/scala/io/quartz/http2/Http2Connection.scala
+++ b/src/main/scala/io/quartz/http2/Http2Connection.scala
@@ -866,10 +866,7 @@ class Http2Connection(
   def closeStream(streamId: Int): IO[Unit] = {
     for {
       _ <- IO(concurrentStreams.decrementAndGet())
-      // known issue: potentialy it's possible for client to reuse old streamId
-      // Something weird about IO.sleep in the current version 50% delay on IO(sleep) creation?, keep original no sleep for now
-      //  _ <- { Temporal[IO].sleep(700.milli) *> IO(streamTbl.remove(streamId)) }.start
-      _ <- IO(streamTbl.remove(streamId))
+      _ <- IO(streamTbl.remove(streamId - 0))
       _ <- Logger[IO].debug(s"Close stream: $streamId")
     } yield ()
 

--- a/src/main/scala/io/quartz/http2/Http2ConnectionCommon.scala
+++ b/src/main/scala/io/quartz/http2/Http2ConnectionCommon.scala
@@ -1,0 +1,191 @@
+package io.quartz.http2
+
+import scala.collection.mutable.ArrayBuffer
+import cats.effect.{IO, Ref, Deferred}
+import cats.effect.std.Queue
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import io.quartz.MyLogger._
+import java.nio.ByteBuffer
+import io.quartz.http2.model.{Request, Response, Headers, ContentType, StatusCode}
+import io.quartz.http2.Constants._
+
+trait Http2ConnectionCommon(
+    val INITIAL_WINDOW_SIZE: Int,
+    val globalBytesOfPendingInboundData: Ref[IO, Long],
+    val globalInboundWindow: Ref[IO, Long],
+    val globalTransmitWindow: Ref[IO, Long],
+    val outq: Queue[IO, ByteBuffer]
+) {
+  private case class txWindow_SplitDataFrame(buffer: ByteBuffer, dataLen: Int)
+
+  protected def takeSlice(buf: ByteBuffer, len: Int): ByteBuffer = {
+    val head = buf.slice.limit(len)
+    buf.position(len)
+    head
+  }
+
+  protected def headerFrame(
+      streamId: Int,
+      settings: Http2Settings,
+      priority: Priority,
+      endStream: Boolean,
+      headerEncoder: HeaderEncoder,
+      headers: Headers
+  ): Seq[ByteBuffer] = {
+    val rawHeaders = headerEncoder.encodeHeaders(headers)
+
+    val limit = settings.MAX_FRAME_SIZE - 61
+
+    val headersPrioritySize =
+      if (priority.isDefined) 5 else 0 // priority(4) + weight(1), padding = 0
+
+    if (rawHeaders.remaining() + headersPrioritySize <= limit) {
+      val acc = new ArrayBuffer[ByteBuffer]
+      acc.addOne(
+        Frames.mkHeaderFrame(
+          streamId,
+          priority,
+          endHeaders = true,
+          endStream,
+          padding = 0,
+          rawHeaders
+        )
+      )
+
+      acc.toSeq
+    } else {
+      // need to fragment
+      val acc = new ArrayBuffer[ByteBuffer]
+
+      val headersBuf = takeSlice(rawHeaders, limit - headersPrioritySize)
+      acc += Frames.mkHeaderFrame(
+        streamId,
+        priority,
+        endHeaders = false,
+        endStream,
+        padding = 0,
+        headersBuf
+      )
+
+      while (rawHeaders.hasRemaining) {
+        val size = math.min(limit, rawHeaders.remaining)
+        val continueBuf = takeSlice(rawHeaders, size)
+        val endHeaders = !rawHeaders.hasRemaining
+        acc += Frames.mkContinuationFrame(streamId, endHeaders, continueBuf)
+      }
+      acc.toSeq
+    }
+  }
+
+  def sendFrame(b: ByteBuffer) = outq.offer(b)
+
+  private def splitDataFrames(
+      bb: ByteBuffer,
+      requiredLen: Long
+  ): (txWindow_SplitDataFrame, Option[txWindow_SplitDataFrame]) = {
+    val original_bb = bb.slice()
+    val len = Frames.getLengthField(bb)
+    val frameType = bb.get()
+    val flags = bb.get()
+    val streamId = Frames.getStreamId(bb)
+
+    val endStream = if ((flags & Flags.END_STREAM) != 0) true else false
+
+    if (requiredLen < len) {
+      val buf0 = Array.ofDim[Byte](requiredLen.toInt)
+      bb.get(buf0)
+
+      val dataFrame1 = Frames.mkDataFrame(streamId, false, padding = 0, ByteBuffer.wrap(buf0))
+      val dataFrame2 = Frames.mkDataFrame(streamId, endStream, padding = 0, bb)
+
+      (
+        txWindow_SplitDataFrame(dataFrame1, requiredLen.toInt),
+        Some(txWindow_SplitDataFrame(dataFrame2, len - requiredLen.toInt))
+      )
+
+    } else (txWindow_SplitDataFrame(original_bb, len), None)
+  }
+
+  private def txWindow_Transmit(stream: Http2StreamCommon, bb: ByteBuffer, data_len: Int): IO[Long] = {
+    for {
+      tx_g <- globalTransmitWindow.get
+      tx_l <- stream.transmitWindow.get
+      bytesCredit <- IO(Math.min(tx_g, tx_l))
+
+      _ <-
+        if (bytesCredit > 0)
+          (for {
+            rlen <- IO(Math.min(bytesCredit, data_len))
+            frames <- IO(splitDataFrames(bb, rlen))
+            _ <- sendFrame(frames._1.buffer)
+            _ <- globalTransmitWindow.update(_ - rlen)
+            _ <- stream.transmitWindow.update(_ - rlen)
+
+            _ <- frames._2 match {
+              case Some(f0) =>
+                stream.outXFlowSync.take >> txWindow_Transmit(stream, f0.buffer, f0.dataLen)
+              case None => IO.unit
+            }
+
+          } yield ())
+        else stream.outXFlowSync.take >> txWindow_Transmit(stream, bb, data_len)
+
+    } yield (bytesCredit)
+  }
+
+  /** Generate stream data frame(s) for the specified data
+    *
+    * If the data exceeds the peers MAX_FRAME_SIZE setting, it is fragmented into a series of frames.
+    */
+  protected def dataFrame(
+      sts: Http2Settings,
+      streamId: Int,
+      endStream: Boolean,
+      data: ByteBuffer
+  ): scala.collection.immutable.Seq[ByteBuffer] = {
+    val limit =
+      sts.MAX_FRAME_SIZE - 128
+
+    if (data.remaining <= limit) {
+
+      val acc = new ArrayBuffer[ByteBuffer]
+      acc.addOne(Frames.mkDataFrame(streamId, endStream, padding = 0, data))
+
+      acc.toSeq
+    } else { // need to fragment
+      val acc = new ArrayBuffer[ByteBuffer]
+
+      while (data.hasRemaining) {
+
+        val len = math.min(data.remaining(), limit)
+
+        val cur_pos = data.position()
+
+        val thisData = data.slice.limit(len)
+
+        data.position(cur_pos + len)
+
+        val eos = endStream && !data.hasRemaining
+        acc.addOne(Frames.mkDataFrame(streamId, eos, padding = 0, thisData))
+      }
+      acc.toSeq
+    }
+  }
+
+  protected def sendDataFrame(streamId: Int, bb: ByteBuffer): IO[Unit] =
+    for {
+      t <- IO(Http2Connection.parseFrame(bb))
+      len = t._1
+      _ <- Logger[IO].trace(s"sendDataFrame() - $len bytes")
+      opt_D <- IO(getStream(streamId))
+      _ <- opt_D match {
+        case Some(ce) =>
+          for {
+            _ <- txWindow_Transmit(ce, bb, len)
+          } yield ()
+        case None => Logger[IO].error("sendDataFrame lost streamId")
+      }
+    } yield ()
+  def getStream(id: Int): Option[Http2StreamCommon]
+}

--- a/src/main/scala/io/quartz/http2/Http2ConnectionCommon.scala
+++ b/src/main/scala/io/quartz/http2/Http2ConnectionCommon.scala
@@ -2,7 +2,7 @@ package io.quartz.http2
 
 import scala.collection.mutable.ArrayBuffer
 import cats.effect.{IO, Ref, Deferred}
-import cats.effect.std.Queue
+import cats.effect.std.{Queue,Semaphore}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.quartz.MyLogger._
@@ -15,7 +15,8 @@ trait Http2ConnectionCommon(
     val globalBytesOfPendingInboundData: Ref[IO, Long],
     val globalInboundWindow: Ref[IO, Long],
     val globalTransmitWindow: Ref[IO, Long],
-    val outq: Queue[IO, ByteBuffer]
+    val outq: Queue[IO, ByteBuffer],
+    val hSem2: Semaphore[IO]
 ) {
   private case class txWindow_SplitDataFrame(buffer: ByteBuffer, dataLen: Int)
 

--- a/src/main/scala/io/quartz/http2/RoutesDsl.scala
+++ b/src/main/scala/io/quartz/http2/RoutesDsl.scala
@@ -60,6 +60,13 @@ object / {
     }
 }
 
+
+object ! {
+   def unapply(req: Request): Option[(String, Request)] =
+     req.sniServerNames.map( array => ( array(0), req ) )
+}
+
+
 object -> {
   def unapply(req: Request): Option[(Method, Path)] =
     for {

--- a/src/main/scala/io/quartz/netio/IOChannel.scala
+++ b/src/main/scala/io/quartz/netio/IOChannel.scala
@@ -8,4 +8,8 @@ trait IOChannel {
   def read( timeOut: Int): IO[Chunk[Byte]]
   def write(buffer: ByteBuffer): IO[Int]
   def close() : IO[Unit]
+  def secure() : Boolean
+  //used in TLS mode to pass parameter from SNI tls extension
+  def sniServerNames() : Option[Array[String]] = None
+
 }

--- a/src/main/scala/io/quartz/netio/SocketChannel.scala
+++ b/src/main/scala/io/quartz/netio/SocketChannel.scala
@@ -37,4 +37,5 @@ class SocketChannel(val socket: Socket) extends IOChannel {
     }
 
   }
+  def secure() = true //true only for this implementation
 }

--- a/src/main/scala/io/quartz/netio/TCPChannel.scala
+++ b/src/main/scala/io/quartz/netio/TCPChannel.scala
@@ -138,4 +138,6 @@ class TCPChannel( val ch: AsynchronousSocketChannel) extends IOChannel {
 
   def close(): IO[Unit] = IO(ch.close)
 
+   def secure() = false
+
 }

--- a/src/main/scala/io/quartz/netio/TLSChannel.scala
+++ b/src/main/scala/io/quartz/netio/TLSChannel.scala
@@ -446,7 +446,6 @@ class TLSChannel(val ctx: SSLContext, rch: TCPChannel) extends IOChannel {
 
   def ssl_init_h2(): IO[Chunk[Byte]] = {
     for {
-      _ <- IO.println("INIT")
       _ <- f_SSL.setUseClientMode(false)
       sslParameters <- IO(f_SSL.engine.getSSLParameters())
       _ <- IO(

--- a/src/main/scala/io/quartz/netio/TLSChannel.scala
+++ b/src/main/scala/io/quartz/netio/TLSChannel.scala
@@ -27,6 +27,7 @@ import java.nio.channels.{
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 import javax.net.ssl.SNIServerName
+import javax.net.ssl.SNIMatcher
 import java.security.cert.X509Certificate
 import java.io.FileInputStream
 import java.io.File
@@ -34,6 +35,7 @@ import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.KeyManagerFactory
 import scala.jdk.CollectionConverters.ListHasAsScala
 import java.nio.ByteBuffer
+import scala.collection.mutable.ListBuffer
 
 sealed case class TLSChannelError(msg: String) extends Exception(msg)
 
@@ -123,8 +125,12 @@ class TLSChannel(val ctx: SSLContext, rch: TCPChannel) extends IOChannel {
   // how many packets we can consume per read() call N of TLS_PACKET_SZ  -> N of APP_PACKET_SZ
   val MULTIPLER = 4
 
+  private[this] val sni_hosts = new ListBuffer[String]()
+
   // prealoc carryover buffer, position getting saved between calls
   private[this] val IN_J_BUFFER = java.nio.ByteBuffer.allocate(TLS_PACKET_SZ * MULTIPLER)
+
+  override def sniServerNames(): Option[Array[String]] = Some(sni_hosts.toArray)
 
   private[this] def doHandshakeClient() = {
     // val BUFF_SZ = ssl_engine.engine.getSession().getPacketBufferSize()
@@ -373,6 +379,8 @@ class TLSChannel(val ctx: SSLContext, rch: TCPChannel) extends IOChannel {
     result.handleErrorWith(_ => IO.unit)
   }
 
+  def secure() = true
+
   class SniName(sniServerName: String) extends SNIServerName(0, sniServerName.getBytes())
   def ssl_initClent_h2(sniServerName: String): IO[Unit] = {
     for {
@@ -427,9 +435,28 @@ class TLSChannel(val ctx: SSLContext, rch: TCPChannel) extends IOChannel {
   // ALPN (Application Layer Protocol Negotiation) for http2
   // returns leftover chunk which needs to be used before we read chanel again.
   // for 99% there will be no leftover but under extreme load or upon JVM init it happens
+
+  private class QuartzSNIMatcher extends SNIMatcher(0) {
+    // def matches​( serveName: SNIServerName ): Boolean = true
+    def matches(name: javax.net.ssl.SNIServerName): Boolean = {
+      sni_hosts.append(String(name.getEncoded()))
+      true
+    }
+  }
+
   def ssl_init_h2(): IO[Chunk[Byte]] = {
     for {
+      _ <- IO.println("INIT")
       _ <- f_SSL.setUseClientMode(false)
+      sslParameters <- IO(f_SSL.engine.getSSLParameters())
+      _ <- IO(
+        sslParameters.setSNIMatchers(
+          Array(new QuartzSNIMatcher()).foldLeft(new java.util.ArrayList[SNIMatcher]())((arr, x) => { arr.add(x); arr })
+        )
+      )
+
+      _ <- IO(f_SSL.engine.setSSLParameters(sslParameters))
+
       _ <- IO(f_SSL.engine.setHandshakeApplicationProtocolSelector((eng, list) => {
         if (list.asScala.find(_ == "h2").isDefined) "h2"
         else null
@@ -449,7 +476,7 @@ class TLSChannel(val ctx: SSLContext, rch: TCPChannel) extends IOChannel {
 
     val res = for {
       out <- IO(ByteBuffer.allocate(if (in.limit() > TLS_PACKET_SZ) in.limit() * 3 else TLS_PACKET_SZ * 3))
-   
+
       loop = for {
         res <- f_SSL.wrap(in, out)
         stat <- IO(res.getStatus())

--- a/src/main/scala/io/quartz/netio/TLSChannel.scala
+++ b/src/main/scala/io/quartz/netio/TLSChannel.scala
@@ -130,7 +130,10 @@ class TLSChannel(val ctx: SSLContext, rch: TCPChannel) extends IOChannel {
   // prealoc carryover buffer, position getting saved between calls
   private[this] val IN_J_BUFFER = java.nio.ByteBuffer.allocate(TLS_PACKET_SZ * MULTIPLER)
 
-  override def sniServerNames(): Option[Array[String]] = Some(sni_hosts.toArray)
+  override def sniServerNames(): Option[Array[String]] = {
+    if( sni_hosts.size == 0 ) None
+    else Some(sni_hosts.toArray)
+  }  
 
   private[this] def doHandshakeClient() = {
     // val BUFF_SZ = ssl_engine.engine.getSession().getPacketBufferSize()


### PR DESCRIPTION
bug fixes:
-  outbound(transmit) split frame with end stream flag was missing the end stream flag.
-  Htttp2Client close() for Http2Client did not close the socket. 
-  Inbound flow control( when to send update window ) rewritten and tested. Earlier code can error out  with large file  when many streams run in parallel.

- TLS Server Name indication( SNI)  name available in Request
-  "!" operator added to match request with TLS SNI, enabling virtual hosting based on SNI,
- Some server/client code moved to common Http2ConnectionCommon/Http2Sream Common base traits.